### PR TITLE
Remove light theme toggle and enforce dark mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -378,23 +378,6 @@
     color: var(--accent-primary);
   }
 
-  .theme-toggle {
-    width: 2.6rem;
-    height: 2.6rem;
-    border-radius: 0.85rem;
-    border: 1px solid var(--border-soft);
-    background: var(--surface-1);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .theme-toggle:hover,
-  .theme-toggle:focus-visible {
-    border-color: var(--accent-primary);
-    color: var(--accent-primary);
-  }
-
   .hero-lead {
     font-size: 1.1rem;
     color: var(--text-muted);

--- a/index.html
+++ b/index.html
@@ -47,24 +47,6 @@
             <div class="hero-panel" data-animate>
               <div class="hero-badge-row">
                 <span class="hero-badge">Full-stack data story</span>
-                <button class="theme-toggle" data-theme-toggle aria-label="Toggle color theme" type="button">
-                  <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                    <path
-                      class="sun-icon"
-                      d="M11 3V1M11 21V19M19 11H21M1 11H3M16.657 5.343L18.071 3.929M3.929 18.071L5.343 16.657M16.657 16.657L18.071 18.071M3.929 3.929L5.343 5.343M15 11C15 13.209 13.209 15 11 15C8.791 15 7 13.209 7 11C7 8.791 8.791 7 11 7C13.209 7 15 8.791 15 11Z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                    />
-                    <path
-                      class="moon-icon"
-                      d="M18 11C18 15.4183 14.4183 19 10 19C5.58172 19 2 15.4183 2 11C2 6.58172 5.58172 3 10 3C10.4614 3 10.9146 3.0395 11.3551 3.11558C10.0153 4.26261 9.1 5.98845 9.1 7.95C9.1 11.4031 11.9969 14.3 15.45 14.3C16.4984 14.3 17.4814 14.054 18.3428 13.6204C18.1169 12.4087 18 11.2101 18 11Z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                    />
-                  </svg>
-                </button>
               </div>
               <h1>
                 NYC Housing Dynamics

--- a/js/modules/state.js
+++ b/js/modules/state.js
@@ -1,5 +1,5 @@
 const createState = () => ({
-  theme: localStorage.getItem('insightlab-theme') || 'dark',
+  theme: 'dark',
   charts: new Map(),
   data: null,
   summary: null,
@@ -33,7 +33,6 @@ export const destroyAllCharts = () => {
 
 export const setTheme = (theme) => {
   appState.theme = theme;
-  localStorage.setItem('insightlab-theme', theme);
 };
 
 export const setData = (payload) => {

--- a/js/modules/theme.js
+++ b/js/modules/theme.js
@@ -1,27 +1,19 @@
-import { appState, setTheme } from './state.js';
+import { setTheme } from './state.js';
 
 const DARK_THEME_COLOR = '#0b1221';
-const LIGHT_THEME_COLOR = '#f5f7fb';
 
 export const initTheme = (onChange) => {
-  const toggle = document.querySelector('[data-theme-toggle]');
   const html = document.documentElement;
   const metaTheme = document.querySelector('meta[name="theme-color"]');
 
-  const applyTheme = (theme) => {
-    const normalized = theme === 'light' ? 'light' : 'dark';
-    html.setAttribute('data-theme', normalized);
-    setTheme(normalized);
+  const applyDarkTheme = () => {
+    html.setAttribute('data-theme', 'dark');
+    setTheme('dark');
     if (metaTheme) {
-      metaTheme.content = normalized === 'dark' ? DARK_THEME_COLOR : LIGHT_THEME_COLOR;
+      metaTheme.content = DARK_THEME_COLOR;
     }
-    onChange?.(normalized);
+    onChange?.('dark');
   };
 
-  toggle?.addEventListener('click', () => {
-    const nextTheme = appState.theme === 'dark' ? 'light' : 'dark';
-    applyTheme(nextTheme);
-  });
-
-  applyTheme(appState.theme);
+  applyDarkTheme();
 };

--- a/study.html
+++ b/study.html
@@ -47,24 +47,6 @@
             <div class="hero-panel" data-animate>
               <div class="hero-badge-row">
                 <span class="hero-badge">Case study companion</span>
-                <button class="theme-toggle" data-theme-toggle aria-label="Toggle color theme" type="button">
-                  <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                    <path
-                      class="sun-icon"
-                      d="M11 3V1M11 21V19M19 11H21M1 11H3M16.657 5.343L18.071 3.929M3.929 18.071L5.343 16.657M16.657 16.657L18.071 18.071M3.929 3.929L5.343 5.343M15 11C15 13.209 13.209 15 11 15C8.791 15 7 13.209 7 11C7 8.791 8.791 7 11 7C13.209 7 15 8.791 15 11Z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                    />
-                    <path
-                      class="moon-icon"
-                      d="M18 11C18 15.4183 14.4183 19 10 19C5.58172 19 2 15.4183 2 11C2 6.58172 5.58172 3 10 3C10.4614 3 10.9146 3.0395 11.3551 3.11558C10.0153 4.26261 9.1 5.98845 9.1 7.95C9.1 11.4031 11.9969 14.3 15.45 14.3C16.4984 14.3 17.4814 14.054 18.3428 13.6204C18.1169 12.4087 18 11.2101 18 11Z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                    />
-                  </svg>
-                </button>
               </div>
               <h1>InsightLab: NYC Housing Dynamics</h1>
               <p class="hero-lead">


### PR DESCRIPTION
## Summary
- remove the theme toggle controls from the index and study pages to keep the experience dark-only
- simplify the theme initialization to always apply the dark palette and drop light-theme storage
- clean up CSS rules that only supported the removed toggle

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163ba9bf98832ea758a4567d161a53)