### PR TITLE
Ensure animated insight panels remain visible without IntersectionObserver

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -727,13 +727,13 @@
     color: var(--text-strong);
   }
 
-  [data-animate] {
+  .has-js [data-animate] {
     opacity: 0;
     transform: translateY(28px);
     transition: opacity 480ms ease, transform 480ms ease;
   }
 
-  [data-animate].is-visible {
+  .has-js [data-animate].is-visible {
     opacity: 1;
     transform: none;
   }

--- a/js/main.js
+++ b/js/main.js
@@ -12,6 +12,8 @@ import { initMetricObservers, updateMetrics } from './modules/metrics.js';
 import { syncNarrative } from './modules/copy.js';
 import { initSmoothScroll, initKeyboardTabs } from './modules/interactions.js';
 
+document.documentElement.classList.add('has-js');
+
 const getActivePeriod = () =>
   document.querySelector('[data-period-tab].is-active')?.getAttribute('data-period-tab') || SCATTER_PERIODS[0].key;
 

--- a/js/modules/viewport.js
+++ b/js/modules/viewport.js
@@ -2,6 +2,11 @@ export const initViewportAnimations = () => {
   const animated = document.querySelectorAll('[data-animate]');
   if (!animated.length) return;
 
+  if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+    animated.forEach((element) => element.classList.add('is-visible'));
+    return;
+  }
+
   const observer = new IntersectionObserver(
     (entries, obs) => {
       entries.forEach((entry) => {


### PR DESCRIPTION
## Summary
- add a `has-js` class on load so animation styling only applies when JavaScript runs
- fall back to revealing animated sections when IntersectionObserver support is missing
- keep insight panels visible even if viewport animations fail so all views are accessible

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163e70bfe8832e933e7f5ab1bb64d1)